### PR TITLE
Update thermal_core.c

### DIFF
--- a/drivers/thermal/thermal_core.c
+++ b/drivers/thermal/thermal_core.c
@@ -40,7 +40,7 @@
 #include <net/genetlink.h>
 #include <linux/suspend.h>
 #include <linux/kobject.h>
-#include <../base/base.h>
+#include "../base/base.h"
 
 #define CREATE_TRACE_POINTS
 #include <trace/events/thermal.h>


### PR DESCRIPTION
fixes error 
'fatal error: no such or file or directory such as  <../base/base.h>'
try #include <../base/base.h> with quotes
  #include "../base/base.h"